### PR TITLE
Upgrade to version 4.0 of the provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.5)
 
-- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 3.71)
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.0)
 
 - <a name="requirement_modtm"></a> [modtm](#requirement\_modtm) (~> 0.3)
 
@@ -814,7 +814,7 @@ Description:   Defaults to `{}`. Manages SQL Databases within a Cosmos DB Accoun
     - `max_throughput` - (Required) - The maximum throughput of the SQL database (RU/s). Must be between `1,000` and `1,000,000`. Must be set in increments of `1,000`. Conflicts with `throughput`.
 
   - `containers` - (Optional) - Defaults to `{}`. Manages SQL Containers within a Cosmos DB Account.
-    - `partition_key_path`     - (Required) - Define a partition key. Changing this forces a new resource to be created.
+    - `partition_key_paths`     - (Required) - Defines the partition key for the container. Changing this forces a new resource to be created.
     - `name`                   - (Required) - Specifies the name of the Cosmos DB SQL Container. Changing this forces a new resource to be created.
     - `throughput`             - (Optional) - Defaults to `null`. The throughput of SQL container (RU/s). Must be set in increments of `100`. The minimum value is `400`. This must be set upon container creation otherwise it cannot be updated without a manual terraform destroy-apply.
     - `default_ttl`            - (Optional) - Defaults to `null`. The default time to live of SQL container. If missing, items are not expired automatically. If present and the value is set to `-1`, it is equal to infinity, and items don't expire by default. If present and the value is set to some number n - items will expire n seconds after their last modified time.
@@ -878,7 +878,7 @@ Description:   Defaults to `{}`. Manages SQL Databases within a Cosmos DB Accoun
 
       containers = {
         container1 = {
-          partition_key_path = "/id"
+          partition_key_paths = ["/id"]
           name               = "container1"
           throughput         = 400
           default_ttl        = 1000
@@ -973,8 +973,8 @@ map(object({
     }), null)
 
     containers = optional(map(object({
-      partition_key_path = string
-      name               = string
+      partition_key_paths = list(string)
+      name                = string
 
       throughput             = optional(number, null)
       default_ttl            = optional(number, null)

--- a/examples/cmk-pin-key-version/README.md
+++ b/examples/cmk-pin-key-version/README.md
@@ -10,7 +10,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.71"
+      version = "~> 4.0"
     }
     random = {
       source  = "hashicorp/random"
@@ -138,7 +138,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.5)
 
-- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 3.71)
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.0)
 
 - <a name="requirement_random"></a> [random](#requirement\_random) (~> 3.6)
 

--- a/examples/cmk-pin-key-version/main.tf
+++ b/examples/cmk-pin-key-version/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.71"
+      version = "~> 4.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/default/README.md
+++ b/examples/default/README.md
@@ -10,7 +10,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.71"
+      version = "~> 4.0"
     }
     random = {
       source  = "hashicorp/random"
@@ -54,8 +54,7 @@ resource "azurerm_resource_group" "example" {
 }
 
 module "cosmos" {
-  source = "../../"
-
+  source              = "../../"
   resource_group_name = azurerm_resource_group.example.name
   location            = azurerm_resource_group.example.location
   name                = "${module.naming.cosmosdb_account.name_unique}-${local.prefix}"
@@ -69,7 +68,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.5)
 
-- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 3.71)
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.0)
 
 - <a name="requirement_random"></a> [random](#requirement\_random) (~> 3.6)
 

--- a/examples/default/main.tf
+++ b/examples/default/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.71"
+      version = "~> 4.0"
     }
     random = {
       source  = "hashicorp/random"
@@ -48,8 +48,7 @@ resource "azurerm_resource_group" "example" {
 }
 
 module "cosmos" {
-  source = "../../"
-
+  source              = "../../"
   resource_group_name = azurerm_resource_group.example.name
   location            = azurerm_resource_group.example.location
   name                = "${module.naming.cosmosdb_account.name_unique}-${local.prefix}"

--- a/examples/managed-identities/README.md
+++ b/examples/managed-identities/README.md
@@ -10,7 +10,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.71"
+      version = "~> 4.0"
     }
     random = {
       source  = "hashicorp/random"
@@ -80,7 +80,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.5)
 
-- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 3.71)
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.0)
 
 - <a name="requirement_random"></a> [random](#requirement\_random) (~> 3.6)
 

--- a/examples/managed-identities/main.tf
+++ b/examples/managed-identities/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.71"
+      version = "~> 4.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/max-account/README.md
+++ b/examples/max-account/README.md
@@ -10,7 +10,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.71"
+      version = "~> 4.0"
     }
     random = {
       source  = "hashicorp/random"
@@ -133,7 +133,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.5)
 
-- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 3.71)
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.0)
 
 - <a name="requirement_random"></a> [random](#requirement\_random) (~> 3.6)
 

--- a/examples/max-account/main.tf
+++ b/examples/max-account/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.71"
+      version = "~> 4.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/mongo/README.md
+++ b/examples/mongo/README.md
@@ -10,7 +10,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.71"
+      version = "~> 4.0"
     }
     random = {
       source  = "hashicorp/random"
@@ -139,7 +139,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.5)
 
-- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 3.71)
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.0)
 
 - <a name="requirement_random"></a> [random](#requirement\_random) (~> 3.6)
 

--- a/examples/mongo/main.tf
+++ b/examples/mongo/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.71"
+      version = "~> 4.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/private-endpoints-managed-dns-records/README.md
+++ b/examples/private-endpoints-managed-dns-records/README.md
@@ -10,7 +10,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.71"
+      version = "~> 4.0"
     }
     random = {
       source  = "hashicorp/random"
@@ -152,7 +152,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.5)
 
-- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 3.71)
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.0)
 
 - <a name="requirement_random"></a> [random](#requirement\_random) (~> 3.6)
 

--- a/examples/private-endpoints-managed-dns-records/main.tf
+++ b/examples/private-endpoints-managed-dns-records/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.71"
+      version = "~> 4.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/private-endpoints-unmanaged-dns-records/README.md
+++ b/examples/private-endpoints-unmanaged-dns-records/README.md
@@ -10,7 +10,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.71"
+      version = "~> 4.0"
     }
     random = {
       source  = "hashicorp/random"
@@ -151,7 +151,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.5)
 
-- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 3.71)
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.0)
 
 - <a name="requirement_random"></a> [random](#requirement\_random) (~> 3.6)
 

--- a/examples/private-endpoints-unmanaged-dns-records/main.tf
+++ b/examples/private-endpoints-unmanaged-dns-records/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.71"
+      version = "~> 4.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/public-restricted-access/README.md
+++ b/examples/public-restricted-access/README.md
@@ -10,7 +10,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.71"
+      version = "~> 4.0"
     }
     random = {
       source  = "hashicorp/random"
@@ -98,7 +98,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.5)
 
-- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 3.71)
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.0)
 
 - <a name="requirement_random"></a> [random](#requirement\_random) (~> 3.6)
 

--- a/examples/public-restricted-access/main.tf
+++ b/examples/public-restricted-access/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.71"
+      version = "~> 4.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/serverless/README.md
+++ b/examples/serverless/README.md
@@ -10,7 +10,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.71"
+      version = "~> 4.0"
     }
     random = {
       source  = "hashicorp/random"
@@ -75,7 +75,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.5)
 
-- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 3.71)
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.0)
 
 - <a name="requirement_random"></a> [random](#requirement\_random) (~> 3.6)
 

--- a/examples/serverless/main.tf
+++ b/examples/serverless/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.71"
+      version = "~> 4.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/sql/README.md
+++ b/examples/sql/README.md
@@ -10,7 +10,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.71"
+      version = "~> 4.0"
     }
     random = {
       source  = "hashicorp/random"
@@ -80,8 +80,8 @@ module "cosmos" {
 
       containers = {
         empty_container = {
-          name               = "empty_container"
-          partition_key_path = "/id"
+          name                = "empty_container"
+          partition_key_paths = ["/id"]
         }
       }
     }
@@ -105,9 +105,9 @@ module "cosmos" {
 
       containers = {
         container_fixed_througput = {
-          name               = "container_fixed_througput"
-          partition_key_path = "/id"
-          throughput         = 400
+          name                = "container_fixed_througput"
+          partition_key_paths = ["/id"]
+          throughput          = 400
         }
       }
     }
@@ -121,8 +121,8 @@ module "cosmos" {
 
       containers = {
         container_fixed_througput = {
-          name               = "container_fixed_througput"
-          partition_key_path = "/id"
+          name                = "container_fixed_througput"
+          partition_key_paths = ["/id"]
 
           autoscale_settings = {
             max_throughput = 4000
@@ -136,14 +136,14 @@ module "cosmos" {
 
       containers = {
         container_fixed_througput = {
-          name               = "container_fixed_througput"
-          partition_key_path = "/id"
-          throughput         = 400
+          name                = "container_fixed_througput"
+          partition_key_paths = ["/id"]
+          throughput          = 400
         }
 
         container_autoscale_througput = {
-          name               = "container_autoscale_througput"
-          partition_key_path = "/id"
+          name                = "container_autoscale_througput"
+          partition_key_paths = ["/id"]
 
           autoscale_settings = {
             max_throughput = 4000
@@ -152,25 +152,25 @@ module "cosmos" {
 
         container_infinite_analytical_ttl = {
           name                   = "container_infinite_analytical_ttl"
-          partition_key_path     = "/id"
+          partition_key_paths    = ["/id"]
           analytical_storage_ttl = -1
         }
 
         container_fixed_analytical_ttl = {
           name                   = "container_fixed_analytical_ttl"
-          partition_key_path     = "/id"
+          partition_key_paths    = ["/id"]
           analytical_storage_ttl = 1000
         }
 
         container_document_ttl = {
-          name               = "container_document_ttl"
-          partition_key_path = "/id"
-          default_ttl        = 1000
+          name                = "container_document_ttl"
+          partition_key_paths = ["/id"]
+          default_ttl         = 1000
         }
 
         container_unique_keys = {
-          name               = "container_unique_keys"
-          partition_key_path = "/id"
+          name                = "container_unique_keys"
+          partition_key_paths = ["/id"]
 
           unique_keys = [
             {
@@ -180,8 +180,8 @@ module "cosmos" {
         }
 
         container_conflict_resolution_with_path = {
-          name               = "container_conflict_resolution_with_path"
-          partition_key_path = "/id"
+          name                = "container_conflict_resolution_with_path"
+          partition_key_paths = ["/id"]
 
           conflict_resolution_policy = {
             mode                     = "LastWriterWins"
@@ -190,8 +190,8 @@ module "cosmos" {
         }
 
         container_conflict_resolution_with_stored_procedure = {
-          name               = "container_conflict_resolution_with_stored_procedure"
-          partition_key_path = "/id"
+          name                = "container_conflict_resolution_with_stored_procedure"
+          partition_key_paths = ["/id"]
 
           conflict_resolution_policy = {
             mode                          = "Custom"
@@ -207,8 +207,8 @@ module "cosmos" {
         }
 
         container_with_functions = {
-          name               = "container_with_functions"
-          partition_key_path = "/id"
+          name                = "container_with_functions"
+          partition_key_paths = ["/id"]
 
           functions = {
             empty = {
@@ -219,8 +219,8 @@ module "cosmos" {
         }
 
         container_with_stored_procedures = {
-          name               = "container_with_stored_procedures"
-          partition_key_path = "/id"
+          name                = "container_with_stored_procedures"
+          partition_key_paths = ["/id"]
 
           stored_procedures = {
             empty = {
@@ -233,8 +233,8 @@ module "cosmos" {
         }
 
         container_with_triggers = {
-          name               = "container_with_triggers"
-          partition_key_path = "/id"
+          name                = "container_with_triggers"
+          partition_key_paths = ["/id"]
 
           triggers = {
             testTrigger = {
@@ -247,8 +247,8 @@ module "cosmos" {
         }
 
         container_with_none_index_policy = {
-          name               = "container_with_none_index_policy"
-          partition_key_path = "/id"
+          name                = "container_with_none_index_policy"
+          partition_key_paths = ["/id"]
 
           indexing_policy = {
             indexing_mode = "none"
@@ -256,8 +256,8 @@ module "cosmos" {
         }
 
         container_with_consistent_index_policy = {
-          name               = "container_with_consistent_index_policy"
-          partition_key_path = "/id"
+          name                = "container_with_consistent_index_policy"
+          partition_key_paths = ["/id"]
 
           indexing_policy = {
             indexing_mode = "consistent"
@@ -310,7 +310,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.5)
 
-- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 3.71)
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.0)
 
 - <a name="requirement_random"></a> [random](#requirement\_random) (~> 3.6)
 

--- a/examples/sql/main.tf
+++ b/examples/sql/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.71"
+      version = "~> 4.0"
     }
     random = {
       source  = "hashicorp/random"
@@ -74,8 +74,8 @@ module "cosmos" {
 
       containers = {
         empty_container = {
-          name               = "empty_container"
-          partition_key_path = "/id"
+          name                = "empty_container"
+          partition_key_paths = ["/id"]
         }
       }
     }
@@ -99,9 +99,9 @@ module "cosmos" {
 
       containers = {
         container_fixed_througput = {
-          name               = "container_fixed_througput"
-          partition_key_path = "/id"
-          throughput         = 400
+          name                = "container_fixed_througput"
+          partition_key_paths = ["/id"]
+          throughput          = 400
         }
       }
     }
@@ -115,8 +115,8 @@ module "cosmos" {
 
       containers = {
         container_fixed_througput = {
-          name               = "container_fixed_througput"
-          partition_key_path = "/id"
+          name                = "container_fixed_througput"
+          partition_key_paths = ["/id"]
 
           autoscale_settings = {
             max_throughput = 4000
@@ -130,14 +130,14 @@ module "cosmos" {
 
       containers = {
         container_fixed_througput = {
-          name               = "container_fixed_througput"
-          partition_key_path = "/id"
-          throughput         = 400
+          name                = "container_fixed_througput"
+          partition_key_paths = ["/id"]
+          throughput          = 400
         }
 
         container_autoscale_througput = {
-          name               = "container_autoscale_througput"
-          partition_key_path = "/id"
+          name                = "container_autoscale_througput"
+          partition_key_paths = ["/id"]
 
           autoscale_settings = {
             max_throughput = 4000
@@ -146,25 +146,25 @@ module "cosmos" {
 
         container_infinite_analytical_ttl = {
           name                   = "container_infinite_analytical_ttl"
-          partition_key_path     = "/id"
+          partition_key_paths    = ["/id"]
           analytical_storage_ttl = -1
         }
 
         container_fixed_analytical_ttl = {
           name                   = "container_fixed_analytical_ttl"
-          partition_key_path     = "/id"
+          partition_key_paths    = ["/id"]
           analytical_storage_ttl = 1000
         }
 
         container_document_ttl = {
-          name               = "container_document_ttl"
-          partition_key_path = "/id"
-          default_ttl        = 1000
+          name                = "container_document_ttl"
+          partition_key_paths = ["/id"]
+          default_ttl         = 1000
         }
 
         container_unique_keys = {
-          name               = "container_unique_keys"
-          partition_key_path = "/id"
+          name                = "container_unique_keys"
+          partition_key_paths = ["/id"]
 
           unique_keys = [
             {
@@ -174,8 +174,8 @@ module "cosmos" {
         }
 
         container_conflict_resolution_with_path = {
-          name               = "container_conflict_resolution_with_path"
-          partition_key_path = "/id"
+          name                = "container_conflict_resolution_with_path"
+          partition_key_paths = ["/id"]
 
           conflict_resolution_policy = {
             mode                     = "LastWriterWins"
@@ -184,8 +184,8 @@ module "cosmos" {
         }
 
         container_conflict_resolution_with_stored_procedure = {
-          name               = "container_conflict_resolution_with_stored_procedure"
-          partition_key_path = "/id"
+          name                = "container_conflict_resolution_with_stored_procedure"
+          partition_key_paths = ["/id"]
 
           conflict_resolution_policy = {
             mode                          = "Custom"
@@ -201,8 +201,8 @@ module "cosmos" {
         }
 
         container_with_functions = {
-          name               = "container_with_functions"
-          partition_key_path = "/id"
+          name                = "container_with_functions"
+          partition_key_paths = ["/id"]
 
           functions = {
             empty = {
@@ -213,8 +213,8 @@ module "cosmos" {
         }
 
         container_with_stored_procedures = {
-          name               = "container_with_stored_procedures"
-          partition_key_path = "/id"
+          name                = "container_with_stored_procedures"
+          partition_key_paths = ["/id"]
 
           stored_procedures = {
             empty = {
@@ -227,8 +227,8 @@ module "cosmos" {
         }
 
         container_with_triggers = {
-          name               = "container_with_triggers"
-          partition_key_path = "/id"
+          name                = "container_with_triggers"
+          partition_key_paths = ["/id"]
 
           triggers = {
             testTrigger = {
@@ -241,8 +241,8 @@ module "cosmos" {
         }
 
         container_with_none_index_policy = {
-          name               = "container_with_none_index_policy"
-          partition_key_path = "/id"
+          name                = "container_with_none_index_policy"
+          partition_key_paths = ["/id"]
 
           indexing_policy = {
             indexing_mode = "none"
@@ -250,8 +250,8 @@ module "cosmos" {
         }
 
         container_with_consistent_index_policy = {
-          name               = "container_with_consistent_index_policy"
-          partition_key_path = "/id"
+          name                = "container_with_consistent_index_policy"
+          partition_key_paths = ["/id"]
 
           indexing_policy = {
             indexing_mode = "consistent"

--- a/locals.tf
+++ b/locals.tf
@@ -30,7 +30,6 @@ locals {
   normalized_cmk_default_identity_type = var.customer_managed_key != null ? "UserAssignedIdentity=${var.customer_managed_key.user_assigned_identity.resource_id}" : null
   normalized_cmk_key_url               = var.customer_managed_key != null ? "https://${local.cmk_keyvault_name}.vault.azure.net/keys/${var.customer_managed_key.key_name}" : null
   normalized_geo_locations             = coalesce(var.geo_locations, local.default_geo_location)
-  normalized_ip_range_filter           = length(local.trimmed_ip_range_filter) > 0 ? join(",", local.trimmed_ip_range_filter) : null
   periodic_backup_policy               = "Periodic"
   private_endpoint_scope_type          = "PrivateEndpoint"
   serverless_capability                = "EnableServerless"

--- a/main.sql.tf
+++ b/main.sql.tf
@@ -31,7 +31,7 @@ resource "azurerm_cosmosdb_sql_container" "this" {
   resource_group_name    = azurerm_cosmosdb_account.this.resource_group_name
   analytical_storage_ttl = each.value.container_params.analytical_storage_ttl
   default_ttl            = each.value.container_params.default_ttl
-  partition_key_path     = each.value.container_params.partition_key_path
+  partition_key_paths    = each.value.container_params.partition_key_paths
   partition_key_version  = 2
   throughput             = each.value.container_params.throughput
 

--- a/main.tf
+++ b/main.tf
@@ -8,7 +8,7 @@ resource "azurerm_cosmosdb_account" "this" {
   automatic_failover_enabled            = var.automatic_failover_enabled
   default_identity_type                 = local.normalized_cmk_default_identity_type
   free_tier_enabled                     = var.free_tier_enabled
-  ip_range_filter                       = local.normalized_ip_range_filter
+  ip_range_filter                       = local.trimmed_ip_range_filter
   is_virtual_network_filter_enabled     = length(var.virtual_network_rules) > 0 ? true : false
   key_vault_key_id                      = local.normalized_cmk_key_url
   kind                                  = length(var.mongo_databases) > 0 ? "MongoDB" : "GlobalDocumentDB"

--- a/terraform.tf
+++ b/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.71"
+      version = "~> 4.0"
     }
     modtm = {
       source  = "azure/modtm"

--- a/variable.sql.tf
+++ b/variable.sql.tf
@@ -43,8 +43,8 @@ variable "sql_databases" {
     }), null)
 
     containers = optional(map(object({
-      partition_key_path = string
-      name               = string
+      partition_key_paths = list(string)
+      name                = string
 
       throughput             = optional(number, null)
       default_ttl            = optional(number, null)
@@ -118,7 +118,7 @@ variable "sql_databases" {
     - `max_throughput` - (Required) - The maximum throughput of the SQL database (RU/s). Must be between `1,000` and `1,000,000`. Must be set in increments of `1,000`. Conflicts with `throughput`.
 
   - `containers` - (Optional) - Defaults to `{}`. Manages SQL Containers within a Cosmos DB Account.
-    - `partition_key_path`     - (Required) - Define a partition key. Changing this forces a new resource to be created.
+    - `partition_key_paths`     - (Required) - Defines the partition key for the container. Changing this forces a new resource to be created.
     - `name`                   - (Required) - Specifies the name of the Cosmos DB SQL Container. Changing this forces a new resource to be created.
     - `throughput`             - (Optional) - Defaults to `null`. The throughput of SQL container (RU/s). Must be set in increments of `100`. The minimum value is `400`. This must be set upon container creation otherwise it cannot be updated without a manual terraform destroy-apply.
     - `default_ttl`            - (Optional) - Defaults to `null`. The default time to live of SQL container. If missing, items are not expired automatically. If present and the value is set to `-1`, it is equal to infinity, and items don't expire by default. If present and the value is set to some number n - items will expire n seconds after their last modified time.
@@ -182,7 +182,7 @@ variable "sql_databases" {
 
       containers = {
         container1 = {
-          partition_key_path = "/id"
+          partition_key_paths = ["/id"]
           name               = "container1"
           throughput         = 400
           default_ttl        = 1000
@@ -360,11 +360,11 @@ variable "sql_databases" {
         for db_key, db_params in var.sql_databases :
         [
           for container_key, container_params in db_params.containers :
-          trimspace(coalesce(container_params.partition_key_path, " ")) != ""
+          length(container_params.partition_key_paths) == 0 ? false : true
         ]
       ])
     )
-    error_message = "The 'partition_key_path' in the containers value must not be empty."
+    error_message = "The 'partition_key_paths' in the containers value must not be empty."
   }
 
   validation {


### PR DESCRIPTION
## Description

Upgrade to version 4.0 of azure rm this is a breaking change especially got cosmosdb databases because of the `partition_key_paths` replaces `partition_key_path`

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [x] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
