### PR TITLE
feat: add sql_database container partition_key_version option

### DIFF
--- a/README.md
+++ b/README.md
@@ -814,7 +814,8 @@ Description:   Defaults to `{}`. Manages SQL Databases within a Cosmos DB Accoun
     - `max_throughput` - (Required) - The maximum throughput of the SQL database (RU/s). Must be between `1,000` and `1,000,000`. Must be set in increments of `1,000`. Conflicts with `throughput`.
 
   - `containers` - (Optional) - Defaults to `{}`. Manages SQL Containers within a Cosmos DB Account.
-    - `partition_key_paths`     - (Required) - Defines the partition key for the container. Changing this forces a new resource to be created.
+    - `partition_key_paths`    - (Required) - Defines the partition key for the container. Changing this forces a new resource to be created.
+    - `partition_key_version`  - (Optional) - Defines the partition key version for the container. Changing this forces a new resource to be created.
     - `name`                   - (Required) - Specifies the name of the Cosmos DB SQL Container. Changing this forces a new resource to be created.
     - `throughput`             - (Optional) - Defaults to `null`. The throughput of SQL container (RU/s). Must be set in increments of `100`. The minimum value is `400`. This must be set upon container creation otherwise it cannot be updated without a manual terraform destroy-apply.
     - `default_ttl`            - (Optional) - Defaults to `null`. The default time to live of SQL container. If missing, items are not expired automatically. If present and the value is set to `-1`, it is equal to infinity, and items don't expire by default. If present and the value is set to some number n - items will expire n seconds after their last modified time.
@@ -879,6 +880,7 @@ Description:   Defaults to `{}`. Manages SQL Databases within a Cosmos DB Accoun
       containers = {
         container1 = {
           partition_key_paths = ["/id"]
+          partition_key_version = 2
           name               = "container1"
           throughput         = 400
           default_ttl        = 1000
@@ -973,8 +975,9 @@ map(object({
     }), null)
 
     containers = optional(map(object({
-      partition_key_paths = list(string)
-      name                = string
+      partition_key_paths   = list(string)
+      partition_key_version = optional(number, 2)
+      name                  = string
 
       throughput             = optional(number, null)
       default_ttl            = optional(number, null)

--- a/main.sql.tf
+++ b/main.sql.tf
@@ -32,7 +32,7 @@ resource "azurerm_cosmosdb_sql_container" "this" {
   resource_group_name    = azurerm_cosmosdb_account.this.resource_group_name
   analytical_storage_ttl = each.value.container_params.analytical_storage_ttl
   default_ttl            = each.value.container_params.default_ttl
-  partition_key_version  = 2
+  partition_key_version  = each.value.container_params.partition_key_version
   throughput             = each.value.container_params.throughput
 
   dynamic "autoscale_settings" {

--- a/variable.sql.tf
+++ b/variable.sql.tf
@@ -43,8 +43,9 @@ variable "sql_databases" {
     }), null)
 
     containers = optional(map(object({
-      partition_key_paths = list(string)
-      name                = string
+      partition_key_paths   = list(string)
+      partition_key_version = optional(number, 2)
+      name                  = string
 
       throughput             = optional(number, null)
       default_ttl            = optional(number, null)
@@ -118,7 +119,8 @@ variable "sql_databases" {
     - `max_throughput` - (Required) - The maximum throughput of the SQL database (RU/s). Must be between `1,000` and `1,000,000`. Must be set in increments of `1,000`. Conflicts with `throughput`.
 
   - `containers` - (Optional) - Defaults to `{}`. Manages SQL Containers within a Cosmos DB Account.
-    - `partition_key_paths`     - (Required) - Defines the partition key for the container. Changing this forces a new resource to be created.
+    - `partition_key_paths`    - (Required) - Defines the partition key for the container. Changing this forces a new resource to be created.
+    - `partition_key_version`  - (Optional) - Defines the partition key version for the container. Changing this forces a new resource to be created.
     - `name`                   - (Required) - Specifies the name of the Cosmos DB SQL Container. Changing this forces a new resource to be created.
     - `throughput`             - (Optional) - Defaults to `null`. The throughput of SQL container (RU/s). Must be set in increments of `100`. The minimum value is `400`. This must be set upon container creation otherwise it cannot be updated without a manual terraform destroy-apply.
     - `default_ttl`            - (Optional) - Defaults to `null`. The default time to live of SQL container. If missing, items are not expired automatically. If present and the value is set to `-1`, it is equal to infinity, and items don't expire by default. If present and the value is set to some number n - items will expire n seconds after their last modified time.
@@ -183,6 +185,7 @@ variable "sql_databases" {
       containers = {
         container1 = {
           partition_key_paths = ["/id"]
+          partition_key_version = 2
           name               = "container1"
           throughput         = 400
           default_ttl        = 1000


### PR DESCRIPTION
## Description

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Closes #456
-->

This pull request adds the possibility to specify the `partition_key_version` for SQL Containers within a Cosmos DB Account, with a default of `2` when not being specified.

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [x] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
