### PR TITLE
respect local_authentication_disabled (avoid overriding caller)

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -12,7 +12,7 @@ resource "azurerm_cosmosdb_account" "this" {
   is_virtual_network_filter_enabled     = length(var.virtual_network_rules) > 0 ? true : false
   key_vault_key_id                      = local.normalized_cmk_key_url
   kind                                  = length(var.mongo_databases) > 0 ? "MongoDB" : "GlobalDocumentDB"
-  local_authentication_disabled         = length(var.sql_databases) > 0 ? var.local_authentication_disabled : false
+  local_authentication_disabled         = length(var.mongo_databases) > 0 ? false : var.local_authentication_disabled
   minimal_tls_version                   = var.minimal_tls_version
   mongo_server_version                  = length(var.mongo_databases) > 0 ? var.mongo_server_version : null
   multiple_write_locations_enabled      = var.backup.type == local.periodic_backup_policy ? var.multiple_write_locations_enabled : false


### PR DESCRIPTION
## Description
This PR fixes a bug where the module forced local_authentication_disabled=false when no SQL databases were present, overriding values passed by callers.\n\nChange: main.tf conditional now omits the attribute for non-SQL accounts instead of forcing false

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #124
Closes #124 
-->

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [X] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [X] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [X] I'm sure there are no other open Pull Requests for the same update/change
- [X] My corresponding pipelines / checks run clean and green without any errors or warnings
- [X] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
