### PR TITLE
fix: respect local_authentication_disabled setting for SQL API accoun…

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -12,7 +12,7 @@ resource "azurerm_cosmosdb_account" "this" {
   is_virtual_network_filter_enabled     = length(var.virtual_network_rules) > 0 ? true : false
   key_vault_key_id                      = local.normalized_cmk_key_url
   kind                                  = length(var.mongo_databases) > 0 ? "MongoDB" : "GlobalDocumentDB"
-  local_authentication_disabled         = length(var.sql_databases) > 0 ? var.local_authentication_disabled : false
+  local_authentication_disabled         = length(var.mongo_databases) > 0 ? false : var.local_authentication_disabled
   minimal_tls_version                   = var.minimal_tls_version
   mongo_server_version                  = length(var.mongo_databases) > 0 ? var.mongo_server_version : null
   multiple_write_locations_enabled      = var.backup.type == local.periodic_backup_policy ? var.multiple_write_locations_enabled : false


### PR DESCRIPTION
…ts (#125)

- For MongoDB accounts: always set local_authentication_disabled = false
- For SQL/other accounts: use caller's var.local_authentication_disabled value
- Fixes issue where module was overriding caller intent by forcing false

This change ensures that:
1. MongoDB accounts get the correct value (false) since they don't support disabling local auth
2. SQL API accounts respect the caller's configuration instead of being overridden
3. Uses consistent logic with the 'kind' attribute for API type detection

## Description

This is the merge branch for the external contribution PR so we can run the tests.

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
