### PR TITLE
feat: add `burst_capacity_enabled` support for Cosmos DB account

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -16,6 +16,7 @@ resource "azurerm_cosmosdb_account" "this" {
   minimal_tls_version                   = var.minimal_tls_version
   mongo_server_version                  = length(var.mongo_databases) > 0 ? var.mongo_server_version : null
   multiple_write_locations_enabled      = var.backup.type == local.periodic_backup_policy ? var.multiple_write_locations_enabled : false
+  burst_capacity_enabled                = var.burst_capacity_enabled
   network_acl_bypass_for_azure_services = var.network_acl_bypass_for_azure_services
   network_acl_bypass_ids                = var.network_acl_bypass_resource_ids
   partition_merge_enabled               = var.partition_merge_enabled

--- a/variables.account.optionals.tf
+++ b/variables.account.optionals.tf
@@ -286,6 +286,13 @@ variable "multiple_write_locations_enabled" {
   nullable    = false
 }
 
+variable "burst_capacity_enabled" {
+  type        = bool
+  default     = false
+  description = "Defaults to `false`. Enable burst capacity for this Cosmos DB account."
+  nullable    = false
+}
+
 variable "partition_merge_enabled" {
   type        = bool
   default     = false


### PR DESCRIPTION
## Description

Adds support for the `burst_capacity_enabled` attribute on the `azurerm_cosmosdb_account` resource.

Burst capacity allows Azure Cosmos DB to use idle throughput capacity across partitions and regions to handle spikes in traffic, improving performance without requiring over-provisioning.

This PR adds:
- A new `burst_capacity_enabled` variable (bool, defaults to `false`) in `variables.account.optionals.tf`
- Wiring of the variable into the `azurerm_cosmosdb_account` resource in `main.tf`

Reference: [Terraform azurerm_cosmosdb_account docs](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cosmosdb_account#burst_capacity_enabled)

## Type of Change

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [x] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks